### PR TITLE
Force the callback url on the CAS server

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ put CAS settings in Meteor.settings (for example using METEOR_SETTINGS env or --
 }
 ```
 
-The ```proxyUrl``` Key:Value pair is only needed if you need to force the callback url. Needed when running through a proxy. Without this value it will read the URL site.
+The ```proxyUrl``` Key:Value pair is only needed if you need to force the callback url. Needed when running through a proxy. Without this value it will read the site URL.
 
 Then, to start authentication, you have to call the following method from the client (for example in a click handler) :
 

--- a/README.md
+++ b/README.md
@@ -5,22 +5,26 @@ CAS login support.
 
 ## Usage
 
-put CAS settings in Meteor.settings (for exemple using METEOR_SETTINGS env or --settings) like so:
+put CAS settings in Meteor.settings (for example using METEOR_SETTINGS env or --settings) like so:
 
 ```
 "cas": {
 	"baseUrl": "https://sso.univ-pau.fr/cas/",
+    "proxyUrl": "https://local-proxy",
  	"autoClose": true
 },
 "public": {
 	"cas": {
 		"loginUrl": "https://sso.univ-pau.fr/cas/login",
+        "proxyUrl": "https://local-proxy",
 		"serviceParam": "service",
 		"popupWidth": 810,
 		"popupHeight": 610
 	}
 }
 ```
+
+The ```proxyUrl``` Key:Value pair is only needed if you need to force the callback url. Needed when running through a proxy. Without this value it will read the URL site.
 
 Then, to start authentication, you have to call the following method from the client (for example in a click handler) :
 

--- a/cas_client.js
+++ b/cas_client.js
@@ -11,9 +11,17 @@ Meteor.loginWithCas = function(callback) {
 
     var settings = Meteor.settings.public.cas;
 
+    var serviceURL = '';
+
+    if (settings.proxyUrl) {
+        serviceURL = settings.proxyUrl + "_cas/";
+    } else {
+        serviceURL = Meteor.absoluteUrl('_cas/');
+    }
+
     var loginUrl = settings.loginUrl +
         "?" + (settings.service || "service") + "=" +
-        Meteor.absoluteUrl('_cas/') +
+        serviceURL +
         credentialToken;
 
     var popup = openCenteredPopup(

--- a/cas_server.js
+++ b/cas_server.js
@@ -58,9 +58,17 @@ var casTicket = function (req, token, callback) {
   var parsedUrl = url.parse(req.url, true);
   var ticketId = parsedUrl.query.ticket;
 
+  var serviceURL = '';
+
+  if (Meteor.settings.cas.proxyUrl) {
+      serviceURL = Meteor.settings.cas.proxyUrl + "_cas/";
+  } else {
+      serviceURL = Meteor.absoluteUrl() + "_cas/";
+  }
+
   var cas = new CAS({
     base_url: Meteor.settings.cas.baseUrl,
-    service: Meteor.absoluteUrl() + "_cas/" + token
+    service: serviceURL + token
   });
 
   cas.validate(ticketId, function(err, status, username) {
@@ -78,7 +86,7 @@ var casTicket = function (req, token, callback) {
     callback();
   });
 
-  return; 
+  return;
 };
 
 /*


### PR DESCRIPTION
I have a situation where the CAS server I am authenticating against only allows certain domains and the connection must be SSL. On my local machine, the meteor app is not secure and at `localhost:3000` (the meteor default) so I run a reverse proxy with nginx to appear like I am from a certain URL and using a self-signed certificate. The way this package gets its URLs for the CAS callback was through `Meteor.absoluteUrl()` so it always used `http://localhost:3000` as the URL and my CAS would reject the request.

This pull request gives you the option of adding "proxyURL" key:value pair to the settings.json. If you do not add this key:value pair it will act just like it always has, but if you have it it will use that URL instead of the result from `Meteor.absoluteUrl()`.
